### PR TITLE
Cargo.toml edit in preparation for crates.io upload

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,10 @@
 name = "shush"
 version = "0.1.0"
 authors = ["John Baublitz <john.baublitz@threatstack.com>"]
+description = "A management tool for silencing Sensu checks written in Rust"
+respository = "https://github.com/threatstack/shush"
+keywords = ["sensu", "monitoring"]
+license = "BSD-3-Clause"
 
 [dependencies]
 futures = "0.1.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "shush"
 version = "0.1.0"
 authors = ["John Baublitz <john.baublitz@threatstack.com>"]
 description = "A management tool for silencing Sensu checks written in Rust"
-respository = "https://github.com/threatstack/shush"
+repository = "https://github.com/threatstack/shush"
 keywords = ["sensu", "monitoring"]
 license = "BSD-3-Clause"
 


### PR DESCRIPTION
We are looking to migrate to crates.io for hosting shush through cargo. This is adds some additional crates.io specific TOML to the Cargo file for more information.