### PR TITLE
Add string interpolation support for config file URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shush"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["John Baublitz <john.baublitz@threatstack.com>"]
 description = "A management tool for silencing Sensu checks written in Rust"
 repository = "https://github.com/threatstack/shush"
@@ -23,3 +23,4 @@ serde_json = "1.0.0"
 getopts = "0.2.14"
 itertools = "0.6.0"
 rust-ini = "0.10.0"
+nom = "^3.2"

--- a/cfg/shush.conf
+++ b/cfg/shush.conf
@@ -1,1 +1,1 @@
-api = http://your.url.here
+api = http://your.${ENV}.here

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,8 @@ extern crate serde_json;
 #[macro_use]
 extern crate itertools;
 extern crate ini;
+#[macro_use]
+extern crate nom;
 
 pub mod opts;
 pub mod sensu_json;
@@ -223,7 +225,7 @@ pub fn main() {
     let args: Vec<String> = env::args().collect();
     let (shush_opts, shush_cfg) = opts::getopts(args);
     let mut sensu_client = match SensuClient::new(shush_cfg.get("api")
-                                                  .cloned().unwrap_or(String::new())
+                                                  .unwrap_or(String::new())
                                                   .as_ref(), 4567) {
         Ok(c) => c,
         Err(e) => {


### PR DESCRIPTION
Currently the shush config file only supports static URLs. Allow string interpolation for environment variables.